### PR TITLE
Fix for updating WebView content

### DIFF
--- a/markdownview/src/main/java/com/mukesh/MarkdownView.java
+++ b/markdownview/src/main/java/com/mukesh/MarkdownView.java
@@ -105,6 +105,7 @@ public class MarkdownView extends WebView {
     } else {
       mPreviewText = String.format("preview('%s')", escMdText);
     }
+    initialize();
   }
 
   private String escapeForText(String mdText) {


### PR DESCRIPTION
Hi,
small thing but without it and with private initialize() you cannot user MarkdownView-Android on any async tasks, only at onCreate, as there is no way to update WebView outside of library.

For test code to reproduce an issue:

```
markdownView = (MarkdownView) findViewById(R.id.markdown_view);
    //markdownView.loadMarkdownFromAssets("README.md");
    Handler handler = new Handler();
    final Runnable r = new Runnable() {
      public void run() {
        if(markdownView != null) {
          markdownView.setMarkDownText("# Hello World\nThis is a simple markdown");
        }
      }
    };

    handler.postDelayed(r, 1000);
```
